### PR TITLE
refactor: use request origin for magic-link if hostUrl not provided

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function generateMagicLink(
 
   const url = new URL(
     options.callbackPath ?? '/',
-    options.hostUrl ?? getHostUrl(options.request),
+    options.hostUrl ?? new URL(options.request.url).origin,
   )
   url.searchParams.set(options.param, options.code)
 
@@ -84,6 +84,13 @@ export async function verifyJWT({ jwt, secretKey }: VerifyJWTOptions) {
 
 /**
  * Miscellaneous.
+ */
+
+/**
+ * Returns the host URL.
+ * This is no longer called by generateMagicLink() since the host in the request headers
+ * may be different from the origin of the request url and the browser would not
+ * find the right cookies for the magic link.
  */
 export function getHostUrl(request: Request) {
   const host = request.headers.get('X-Forwarded-Host') ?? request.headers.get('host')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,25 +81,3 @@ export async function verifyJWT({ jwt, secretKey }: VerifyJWTOptions) {
     throw new Error(ERRORS.INVALID_JWT)
   }
 }
-
-/**
- * Miscellaneous.
- */
-
-/**
- * Returns the host URL.
- * This is no longer called by generateMagicLink() since the host in the request headers
- * may be different from the origin of the request url and the browser would not
- * find the right cookies for the magic link.
- */
-export function getHostUrl(request: Request) {
-  const host = request.headers.get('X-Forwarded-Host') ?? request.headers.get('host')
-  if (!host) throw new Error('Could not determine host.')
-
-  // If the host is localhost or ends with .local, use http.
-  const protocol = host.match(/(:?\.local|^localhost|^127\.\d+\.\d+\.\d+)(:?:\d+)?$/)
-    ? 'http'
-    : 'https'
-
-  return `${protocol}://${host}`
-}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -707,7 +707,7 @@ describe('[ TOTP ]', () => {
 })
 
 describe('[ Utils ]', () => {
-  test('Should properly use the HTTP protocol for local environments.', async () => {
+  test('Should use the HTTP protocol for local environments.', async () => {
     const request = new Request(`${HOST_URL}`)
     const samples: Array<[string, 'http:' | 'https:']> = [
       ['127.0.0.1', 'http:'],
@@ -729,7 +729,7 @@ describe('[ Utils ]', () => {
     }
   })
 
-  test('Should use the origin from the request for the magic link if hostUrl is not provided.', async () => {
+  test('Should use the origin from the request for the magic-link if hostUrl is not provided.', async () => {
     const samples: Array<[string, string]> = [
       ['http://localhost/login', 'http://localhost/magic-link?code=U2N2EY'],
       ['http://localhost:3000/login', 'http://localhost:3000/magic-link?code=U2N2EY'],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -8,6 +8,7 @@ import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from '../src/constan
 import {
   SECRET_ENV,
   HOST_URL,
+  HOST,
   AUTH_OPTIONS,
   TOTP_GENERATION_DEFAULTS,
   MAGIC_LINK_GENERATION_DEFAULTS,
@@ -275,7 +276,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -308,7 +309,7 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
+        headers: { host: HOST },
         body: formData,
       })
 
@@ -334,7 +335,7 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
+        headers: { host: HOST },
         body: formData,
       })
 
@@ -370,7 +371,7 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
+        headers: { host: HOST },
         body: formData,
       })
 
@@ -410,7 +411,7 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
+        headers: { host: HOST },
         body: formData,
       })
 
@@ -450,7 +451,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -495,7 +496,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -544,7 +545,7 @@ describe('[ TOTP ]', () => {
         param: 'code',
         code: _otp,
         request: new Request(HOST_URL, {
-          headers: { host: HOST_URL },
+          headers: { host: HOST },
         }),
       })
 
@@ -554,7 +555,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${magicLink}`, {
         method: 'GET',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
       })
@@ -590,13 +591,13 @@ describe('[ TOTP ]', () => {
         param: 'code',
         code: _otp,
         request: new Request(HOST_URL, {
-          headers: { host: HOST_URL },
+          headers: { host: HOST },
         }),
       })
 
       const request = new Request(`${magicLink}`, {
         method: 'GET',
-        headers: { host: HOST_URL },
+        headers: { host: HOST },
       })
 
       const strategy = new TOTPStrategy(
@@ -635,7 +636,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -679,7 +680,7 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST_URL,
+          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -725,6 +726,32 @@ describe('[ Utils ]', () => {
     for (const [host, protocol] of samples) {
       request.headers.set('host', host)
       expect(getHostUrl(request).startsWith(protocol)).toBe(true)
+    }
+  })
+
+  test('Should use the origin from the request for the magic link if hostUrl is not provided.', async () => {
+    const samples: Array<[string, string]> = [
+      ['http://localhost/login', 'http://localhost/magic-link?code=U2N2EY'],
+      ['http://localhost:3000/login', 'http://localhost:3000/magic-link?code=U2N2EY'],
+      ['http://127.0.0.1/login', 'http://127.0.0.1/magic-link?code=U2N2EY'],
+      ['http://127.0.0.1:3000/login', 'http://127.0.0.1:3000/magic-link?code=U2N2EY'],
+      ['http://localhost:8788/signin', 'http://localhost:8788/magic-link?code=U2N2EY'],
+      ['https://host.com/login', 'https://host.com/magic-link?code=U2N2EY'],
+      ['https://host.com:3000/login', 'https://host.com:3000/magic-link?code=U2N2EY'],
+    ]
+
+    for (const [requestUrl, magicLinkUrl] of samples) {
+      const request = new Request(requestUrl, {
+        headers: { host: HOST },
+      })
+      expect(
+        generateMagicLink({
+          ...MAGIC_LINK_GENERATION_DEFAULTS,
+          param: 'code',
+          code: 'U2N2EY',
+          request,
+        }),
+      ).toBe(magicLinkUrl)
     }
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,13 +2,12 @@ import { describe, test, expect, afterEach, vi } from 'vitest'
 import { AuthorizationError } from 'remix-auth'
 
 import { TOTPStrategy } from '../src/index'
-import { generateTOTP, generateMagicLink, getHostUrl, signJWT } from '../src/utils'
+import { generateTOTP, generateMagicLink, signJWT } from '../src/utils'
 import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from '../src/constants'
 
 import {
   SECRET_ENV,
   HOST_URL,
-  HOST,
   AUTH_OPTIONS,
   TOTP_GENERATION_DEFAULTS,
   MAGIC_LINK_GENERATION_DEFAULTS,
@@ -276,7 +275,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -309,7 +307,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST },
         body: formData,
       })
 
@@ -335,7 +332,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST },
         body: formData,
       })
 
@@ -371,7 +367,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST },
         body: formData,
       })
 
@@ -411,7 +406,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST },
         body: formData,
       })
 
@@ -451,7 +445,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -496,7 +489,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -544,9 +536,7 @@ describe('[ TOTP ]', () => {
         callbackPath: '/magic-link',
         param: 'code',
         code: _otp,
-        request: new Request(HOST_URL, {
-          headers: { host: HOST },
-        }),
+        request: new Request(HOST_URL),
       })
 
       const session = await sessionStorage.getSession()
@@ -555,7 +545,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${magicLink}`, {
         method: 'GET',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
       })
@@ -590,14 +579,11 @@ describe('[ TOTP ]', () => {
         callbackPath: '/invalid',
         param: 'code',
         code: _otp,
-        request: new Request(HOST_URL, {
-          headers: { host: HOST },
-        }),
+        request: new Request(HOST_URL),
       })
 
       const request = new Request(`${magicLink}`, {
         method: 'GET',
-        headers: { host: HOST },
       })
 
       const strategy = new TOTPStrategy(
@@ -636,7 +622,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -680,7 +665,6 @@ describe('[ TOTP ]', () => {
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
         headers: {
-          host: HOST,
           cookie: await sessionStorage.commitSession(session),
         },
         body: formData,
@@ -707,28 +691,6 @@ describe('[ TOTP ]', () => {
 })
 
 describe('[ Utils ]', () => {
-  test('Should use the HTTP protocol for local environments.', async () => {
-    const request = new Request(`${HOST_URL}`)
-    const samples: Array<[string, 'http:' | 'https:']> = [
-      ['127.0.0.1', 'http:'],
-      ['127.1.1.1', 'http:'],
-      ['127.0.0.1:8888', 'http:'],
-      ['localhost', 'http:'],
-      ['localhost:3000', 'http:'],
-      ['remix.run', 'https:'],
-      ['remix.run:3000', 'https:'],
-      ['local.com', 'https:'],
-      ['legit.local.com:3000', 'https:'],
-      ['remix-auth-otp.local', 'http:'],
-      ['remix-auth-otp.local:3000', 'http:'],
-    ]
-
-    for (const [host, protocol] of samples) {
-      request.headers.set('host', host)
-      expect(getHostUrl(request).startsWith(protocol)).toBe(true)
-    }
-  })
-
   test('Should use the origin from the request for the magic-link if hostUrl is not provided.', async () => {
     const samples: Array<[string, string]> = [
       ['http://localhost/login', 'http://localhost/magic-link?code=U2N2EY'],
@@ -741,9 +703,7 @@ describe('[ Utils ]', () => {
     ]
 
     for (const [requestUrl, magicLinkUrl] of samples) {
-      const request = new Request(requestUrl, {
-        headers: { host: HOST },
-      })
+      const request = new Request(requestUrl)
       expect(
         generateMagicLink({
           ...MAGIC_LINK_GENERATION_DEFAULTS,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,6 @@ import * as crypto from 'crypto'
  */
 export const SECRET_ENV = 'SECRET_ENV'
 export const HOST_URL = 'http://localhost:3000'
-export const HOST = 'localhost:3000'
 export const DEFAULT_EMAIL = 'localhost@3000.com'
 
 /**

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,7 +10,8 @@ import * as crypto from 'crypto'
  * Constants.
  */
 export const SECRET_ENV = 'SECRET_ENV'
-export const HOST_URL = 'localhost:3000'
+export const HOST_URL = 'http://localhost:3000'
+export const HOST = 'localhost:3000'
 export const DEFAULT_EMAIL = 'localhost@3000.com'
 
 /**


### PR DESCRIPTION
Generate magic link using the origin of the request rather than the host in the request headers if the hostUrl option is not provided.

In Cloudflare local dev (ie. wrangler/miniflare), the origin of the request will be different from the host in the headers. If the magic link is generated based on the host in the headers, the browser will not find the right cookies.

For example, if the request url is `http://localhost:8788/login` and the corresponding host in the headers is `127.0.0.1:51754`, the magic link would look like `http://127.0.0.1:59073/magic-link?code=JF2C49`. The browser would use the cookies for `127.0.0.1:51754` instead of `localhost:8788`.

With this PR, the magic link would look like `http://localhost:8788/magic-link?code=JF2C49` and the right cookies would be used.

In `test/utils.ts`, the constant `HOST_URL = 'localhost:3000'` is more a `host` per https://developer.mozilla.org/en-US/docs/Web/API/URL/host rather than a `url`. This PR changes it to `HOST_URL = 'http://localhost:3000'` and adds `HOST = 'localhost:3000'`. The tests have been updated accordingly.

In `src/utils.ts`, getHostUrl() is no longer called by generateMagicLink() and has a comment reflecting that. It may be a candidate for removal.

For reference, bing chat has this to say regarding "with an http request, what situations would the host in the request headers be different from the domain in the request url? how does x-forwarded host in request headers figure in all this?"

"In some cases, the host in the request headers can be different from the domain in the request URL. This can happen when the request is forwarded by a proxy server or a load balancer. The host header is used to specify the domain name of the server that the client is trying to reach, while the domain in the request URL is the domain name of the resource that the client is trying to access. When the request is forwarded by a proxy server or a load balancer, the host header can be modified to reflect the domain name of the server that the client is trying to reach 123."