### PR TITLE
Make TOTP_NOT_FOUND error message customizable and Remove hostUrl from MagicLinkGenerationOptions

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -75,7 +75,7 @@ authenticator.use(
 The Magic Link is optional and enabled by default. You can decide to opt-out by setting the `enabled` option to `false`.
 
 Furthermore, the Magic Link can be customized via the `magicLinkGeneration` object in the TOTPStrategy Instance.
-The URL link generated will be in the format of `{hostURL}{callbackPath}?{codeField}=<magic-link-code>`.
+The URL link generated will be in the format of `{request url origin}{callbackPath}?{codeField}=<magic-link-code>`.
 
 ```ts
 export interface MagicLinkGenerationOptions {
@@ -84,12 +84,6 @@ export interface MagicLinkGenerationOptions {
    * @default true
    */
   enabled?: boolean
-  /**
-   * The host URL for the Magic Link.
-   * If omitted, it will be inferred from the request.
-   * @default undefined
-   */
-  hostUrl?: string
   /**
    * The callback path for the Magic Link.
    * @default '/magic-link'

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -122,6 +122,11 @@ export interface CustomErrorsOptions {
    * The inactive TOTP error message.
    */
   inactiveTotp?: string
+    /**
+   * The TOTP not found error message.
+   */
+  totpNotFound?: string
+
 }
 
 authenticator.use(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,13 +16,13 @@ export const ERRORS = {
   INVALID_EMAIL: 'Email is not valid.',
   INVALID_TOTP: 'Code is not valid.',
   INACTIVE_TOTP: 'Code is no longer active.',
+  TOTP_NOT_FOUND: 'Database TOTP not found.',
 
   // Miscellaneous errors.
   REQUIRED_ENV_SECRET: 'Missing required .env secret.',
   REQUIRED_SUCCESS_REDIRECT_URL: 'Missing required successRedirect URL.',
 
   USER_NOT_FOUND: 'User not found.',
-  TOTP_NOT_FOUND: 'Database TOTP not found.',
 
   INVALID_MAGIC_LINK_PATH: 'Invalid magic-link expected path.',
   INVALID_JWT: 'Invalid JWT.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,6 +209,11 @@ export interface CustomErrorsOptions {
    * The inactive TOTP error message.
    */
   inactiveTotp?: string
+
+  /**
+   * The TOTP not found error message.
+   */
+  totpNotFound?: string
 }
 
 /**
@@ -352,6 +357,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
     invalidEmail: ERRORS.INVALID_EMAIL,
     invalidTotp: ERRORS.INVALID_TOTP,
     inactiveTotp: ERRORS.INACTIVE_TOTP,
+    totpNotFound: ERRORS.TOTP_NOT_FOUND,
   } satisfies CustomErrorsOptions
 
   constructor(
@@ -547,7 +553,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
       if (error instanceof Error) {
         if (error.message === ERRORS.INVALID_JWT) {
           const dbTOTP = await this.handleTOTP(sessionTotp)
-          if (!dbTOTP || !dbTOTP.hash) throw new Error(ERRORS.TOTP_NOT_FOUND)
+          if (!dbTOTP || !dbTOTP.hash) throw new Error(this.customErrors.totpNotFound)
 
           await this.handleTOTP(sessionTotp, { active: false })
 
@@ -601,7 +607,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
   private async _validateTOTP(sessionTotp: string, otp: string) {
     // Retrieve encrypted TOTP from database.
     const dbTOTP = await this.handleTOTP(sessionTotp)
-    if (!dbTOTP || !dbTOTP.hash) throw new Error(ERRORS.TOTP_NOT_FOUND)
+    if (!dbTOTP || !dbTOTP.hash) throw new Error(this.customErrors.totpNotFound)
 
     if (dbTOTP.active !== true) {
       throw new Error(this.customErrors.inactiveTotp)

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,14 +67,6 @@ export interface MagicLinkGenerationOptions {
   enabled?: boolean
 
   /**
-   * The host URL for the Magic Link.
-   * If omitted, it will be inferred from the Request.
-   *
-   * @default undefined
-   */
-  hostUrl?: string
-
-  /**
    * The callback URL path for the Magic Link.
    * @default '/magic-link'
    */
@@ -349,7 +341,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
   } satisfies TOTPGenerationOptions
   private readonly _magicLinkGenerationDefaults = {
     enabled: true,
-    hostUrl: undefined,
     callbackPath: '/magic-link',
   } satisfies MagicLinkGenerationOptions
   private readonly _customErrorsDefaults = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,7 @@ export function generateMagicLink(
 
   const url = new URL(
     options.callbackPath ?? '/',
-    options.hostUrl ?? new URL(options.request.url).origin,
+    new URL(options.request.url).origin,
   )
   url.searchParams.set(options.param, options.code)
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -726,7 +726,7 @@ describe('[ TOTP ]', () => {
 })
 
 describe('[ Utils ]', () => {
-  test('Should use the origin from the request for the magic-link if hostUrl is not provided.', async () => {
+  test('Should use the origin from the request for the magic-link.', async () => {
     const samples: Array<[string, string]> = [
       ['http://localhost/login', 'http://localhost/magic-link?code=U2N2EY'],
       ['http://localhost:3000/login', 'http://localhost:3000/magic-link?code=U2N2EY'],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -34,7 +34,6 @@ export const TOTP_GENERATION_DEFAULTS = {
 
 export const MAGIC_LINK_GENERATION_DEFAULTS = {
   enabled: true,
-  hostUrl: undefined,
   callbackPath: '/magic-link',
 } satisfies MagicLinkGenerationOptions
 


### PR DESCRIPTION
Closes #32, #33 

If this PR is accepted, please hold off on releasing since I'd like to propose a change with expireAt which I create an issue for.