### PR TITLE
[ Refactor ] Explicit CRUD Operations and Expiration Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,19 @@ npm install remix-auth-totp
 
 ## Usage
 
-Remix Auth TOTP exports three required methods:
+Remix Auth TOTP exports four required methods:
 
-- `storeTOTP` - Stores the generated OTP into database.
-- `sendTOTP` - Sends the OTP to the user via email or any other method.
-- `handleTOTP` - Handles / Updates the already stored OTP from database.
+- `createTOTP` - Create the TOTP data in the database.
+- `readTOTP` - Read the TOTP data from the database.
+- `updateTOTP` - Update the TOTP data in the database.
+- `sendTOTP` - Sends the TOTP code to the user via email or any other method.
 
 Here's a basic overview of the authentication process.
 
 1. The user signs-up / logs-in via email address.
-2. The Strategy generates a new OTP, stores it and sends it to the user.
+2. The Strategy generates a new TOTP, stores it and sends it to the user.
 3. The user submits the code via form submission / magic-link click.
-4. The Strategy validates the OTP code and authenticates the user.
+4. The Strategy validates the TOTP code and authenticates the user.
    <br />
 
 > [!NOTE]
@@ -71,7 +72,7 @@ Let's see how we can implement the Strategy into our Remix App.
 
 ## Database
 
-We'll require a database to store our encrypted OTP codes.
+We'll require a database to store our TOTP data.
 
 For this example we'll use Prisma ORM with a SQLite database. As long as your database supports the following fields, you can use any database of choice.
 
@@ -83,25 +84,23 @@ For this example we'll use Prisma ORM with a SQLite database. As long as your da
  * - `attempts`: Int (Number), default: 0
  *
  * Optional Fields:
- * - `expiresAt`: DateTime (Date), @default(now()) | String, @default("")
+ * - `expiresAt`: DateTime (Date)
  */
 model Totp {
-  id String @id @default(uuid())
-
   /// The encrypted data used to generate the OTP.
   hash String @unique
 
-  /// The status of the OTP.
-  /// Used internally / programmatically to invalidate OTPs.
-  active Boolean @default(true)
+  /// The status of the TOTP.
+  /// Used internally / programmatically to invalidate TOTPs.
+  active Boolean
 
-  /// The input attempts of the OTP.
-  /// Used internally to invalidate OTPs after a certain amount of attempts.
-  attempts Int @default(0)
+  /// The input attempts of the TOTP.
+  /// Used internally to invalidate TOTPs after a certain amount of attempts.
+  attempts Int
 
-  /// The expiration date of the OTP.
-  /// Used programmatically to invalidate unused OTPs.
-  expiresAt DateTime? @default(now())
+  /// The expiration date of the TOTP.
+  /// Used programmatically to invalidate unused TOTPs.
+  expiresAt DateTime
 }
 ```
 
@@ -188,9 +187,10 @@ authenticator.use(
   new TOTPStrategy(
     {
       secret: process.env.ENCRYPTION_SECRET || 'NOT_A_STRONG_SECRET',
-      storeTOTP: async (data) => {},
+      createTOTP: async (data, expiresAt) => {},
+      readTOTP: async (hash) => {},
+      updateTOTP: async (hash, data, expiresAt) => {},
       sendTOTP: async ({ email, code, magicLink, user, form, request }) => {},
-      handleTOTP: async (hash, data) => {},
     },
     async ({ email, code, form, magicLink, request }) => {},
   ),
@@ -202,36 +202,27 @@ authenticator.use(
 
 ### 2: Implementing the Strategy Logic.
 
-The Strategy Instance requires the following three methods: `storeTOTP`, `sendTOTP`, `handleTOTP`.
+The Strategy Instance requires the following four methods: `createTOTP`, `readTOTP`, `updateTOTP`, `sendTOTP`.
 
 ```ts
 authenticator.use(
   new TOTPStrategy({
     secret: process.env.ENCRYPTION_SECRET,
 
-    storeTOTP: async (data) => {
-      // Store the generated OTP into database.
-      await db.totp.create({ data })
+    createTOTP: async (data, expiresAt) => {
+      // Create the TOTP data in the database along with expiresAt.
+      await db.totp.create({ data, expiresAt })
+    },
+    readTOTP: async (hash) => {
+      return await db.totp.findUnique({ where: { hash } })
+    },
+    updateTOTP: async (hash, data, expiresAt) => {
+      // No need to update expiresAt since it does not change after createTOTP().
+      await db.totp.update({ where: { hash }, data })
     },
     sendTOTP: async ({ email, code, magicLink }) => {
-      // Send the generated OTP to the user.
+      // Send the TOTP code to the user.
       await sendEmail({ email, code, magicLink })
-    },
-    handleTOTP: async (hash, data) => {
-      const totp = await db.totp.findUnique({ where: { hash } })
-
-      // If `data` is provided, the Strategy will update the totp.
-      // Used for internal checks / invalidations.
-      if (data) {
-        return await db.totp.update({
-          where: { hash },
-          data: { ...data },
-        })
-      }
-
-      // Otherwise, we'll return it.
-      // Used for internal checks / validations.
-      return totp
     },
 
     async ({ email, code, magicLink, form, request }) => {},
@@ -249,10 +240,10 @@ This should return the user data that will be stored in Session.
 
 ```ts
 authenticator.use(
-  new OTPStrategy(
+  new TOTPStrategy(
     {
       // We've already set up these options.
-      // storeTOTP: async (data) => {},
+      // createTOTP: async (data) => {},
       // ...
     },
     async ({ email, code, magicLink, form, request }) => {
@@ -447,7 +438,7 @@ If you found this library helpful, please consider leaving us a ⭐ [star](https
 
 ### Acknowledgments
 
-Bit thanks to [@w00fz](https://github.com/w00fz) for its amazing implementation of the **Magic Link feature** and to [@mw10013](https://github.com/mw10013) for the **Cloudflare support** and the dedication set into the implementation.
+Big thanks to [@w00fz](https://github.com/w00fz) for its amazing implementation of the **Magic Link feature** and to [@mw10013](https://github.com/mw10013) for the **Cloudflare support** and the dedication set into the implementation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -78,12 +78,10 @@ For this example we'll use Prisma ORM with a SQLite database. As long as your da
 
 ```ts
 /**
- * Required Fields:
+ * Fields:
  * - `hash`: String
  * - `active`: Boolean, default: true
  * - `attempts`: Int (Number), default: 0
- *
- * Optional Fields:
  * - `expiresAt`: DateTime (Date)
  */
 model Totp {

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,3 +11,4 @@ Welcome to the Remix Auth TOTP documentation! Here you'll find everything you ne
 - [Getting Started](https://github.com/dev-xo/remix-auth-totp/blob/main/README.md) - A quick start guide to get you up and running.
 - [Examples](https://github.com/dev-xo/remix-auth-totp/blob/main/docs/examples.md) - A list of community examples using Remix Auth TOTP.
 - [Customization](https://github.com/dev-xo/remix-auth-totp/blob/main/docs/customization.md) - A detailed guide of all the available options and customizations.
+- [Migration](https://github.com/dev-xo/remix-auth-totp/blob/main/docs/migration.md) - v1 to v2 migration guide.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -60,7 +60,7 @@ export interface TOTPGenerationOptions {
 }
 
 authenticator.use(
-  new OTPStrategy({
+  new TOTPStrategy({
     codeGeneration: {
       digits: 6,
       period: 60,
@@ -124,7 +124,7 @@ export interface CustomErrorsOptions {
 }
 
 authenticator.use(
-  new OTPStrategy({
+  new TOTPStrategy({
     customErrors: {
       requiredEmail: 'Whoops, email is required.',
     },
@@ -167,6 +167,12 @@ export interface TOTPStrategyOptions<User> {
    * @default "auth:totp"
    */
   sessionTotpKey?: string
+  /**
+   * The session key that stores the expiration of the TOTP.
+   * @default "auth:totpExpiresAt"
+   */
+  sessionTotpExpiresAtKey?: string
+
 }
 ```
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,6 @@
 ## Migration
 
-Migrating from v1 to v2
+This document aims to assist you in migrating your `remix-auth-totp` implementation from `v1` to `v2`.
 
 ### Database
 
@@ -12,15 +12,15 @@ model Totp {
   active Boolean
   attempts Int
 
-  // Add expiresAt field
+  // Add `expiresAt` field.
   expiresAt DateTime
 }
 ```
 
 ### Implement `remix-auth-totp` API
 
-- Remove `storeTOTP` and `handleTOTP`.
-- Add `createTOTP`, `readTOTP` and `updateTOTP`.
+- Remove `storeTOTP` and `handleTOTP` from `TOTPStrategy` options.
+- Add `createTOTP`, `readTOTP` and `updateTOTP` to `TOTPStrategy` options.
 
 ```ts
 authenticator.use(
@@ -28,10 +28,10 @@ authenticator.use(
     {
       secret: process.env.ENCRYPTION_SECRET,
 
-      // storeTOTP and handleTOTP deleted.
+      // ❗`storeTOTP` and `handleTOTP` are no longer needed (removed).
 
       createTOTP: async (data, expiresAt) => {
-        // Create the TOTP data in the database along with expiresAt.
+        // Create the TOTP data in the database along with `expiresAt`.
         await db.totp.create({ data, expiresAt })
       },
       readTOTP: async (hash) => {
@@ -40,14 +40,14 @@ authenticator.use(
       },
       updateTOTP: async (hash, data, expiresAt) => {
         // Update the TOTP data in the database.
-        // No need to update expiresAt since it does not change after createTOTP().
+        // No need to update `expiresAt` since it does not change after createTOTP() is called.
         await db.totp.update({ where: { hash }, data })
       },
 
-      // Unchanged
+      // Unchanged.
       sendTOTP: async ({ email, code, magicLink }) => {},
     },
-    // Unchanged
+    // Unchanged.
     async ({ email, code, magicLink, form, request }) => {},
   ),
 )

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,54 @@
+## Migration
+
+Migrating from v1 to v2
+
+### Database
+
+Add `expiresAt` field to `Totp` model if it's not already there.
+
+```ts
+model Totp {
+  hash String @unique
+  active Boolean
+  attempts Int
+
+  // Add expiresAt field
+  expiresAt DateTime
+}
+```
+
+### Implement `remix-auth-totp` API
+
+- Remove `storeTOTP` and `handleTOTP`.
+- Add `createTOTP`, `readTOTP` and `updateTOTP`.
+
+```ts
+authenticator.use(
+  new TOTPStrategy(
+    {
+      secret: process.env.ENCRYPTION_SECRET,
+
+      // storeTOTP and handleTOTP deleted.
+
+      createTOTP: async (data, expiresAt) => {
+        // Create the TOTP data in the database along with expiresAt.
+        await db.totp.create({ data, expiresAt })
+      },
+      readTOTP: async (hash) => {
+        // Get the TOTP data from the database.
+        return await db.totp.findUnique({ where: { hash } })
+      },
+      updateTOTP: async (hash, data, expiresAt) => {
+        // Update the TOTP data in the database.
+        // No need to update expiresAt since it does not change after createTOTP().
+        await db.totp.update({ where: { hash }, data })
+      },
+
+      // Unchanged
+      sendTOTP: async ({ email, code, magicLink }) => {},
+    },
+    // Unchanged
+    async ({ email, code, magicLink, form, request }) => {},
+  ),
+)
+```

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const FORM_FIELDS = {
 export const SESSION_KEYS = {
   EMAIL: 'auth:email',
   TOTP: 'auth:totp',
+  TOTP_EXPIRES_AT: 'auth:totp:expiresAt',
 } as const
 
 export const ERRORS = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,12 +21,9 @@ export const ERRORS = {
 
   // Miscellaneous errors.
   REQUIRED_ENV_SECRET: 'Missing required .env secret.',
-  REQUIRED_SUCCESS_REDIRECT_URL: 'Missing required successRedirect URL.',
-
   USER_NOT_FOUND: 'User not found.',
-
-  INVALID_MAGIC_LINK_PATH: 'Invalid magic-link expected path.',
   INVALID_JWT: 'Invalid JWT.',
-
+  INVALID_MAGIC_LINK_PATH: 'Invalid magic-link expected path.',
+  REQUIRED_SUCCESS_REDIRECT_URL: 'Missing required successRedirect URL.',
   UNKNOWN_ERROR: 'Unknown error.',
 } as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -409,12 +409,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
     const sessionTotpExpiresAt = session.get(this.sessionTotpExpiresAtKey)
 
     let user: User | null = session.get(options.sessionKey) ?? null
-    console.log('authenticate:', {
-      sessionEmail,
-      sessionTotp,
-      sessionTotpExpiresAt,
-      user,
-    })
 
     let formData: FormData | undefined = undefined
     let formDataEmail: string | undefined = undefined
@@ -432,7 +426,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
 
           formDataEmail = form[this.emailFieldKey] && String(form[this.emailFieldKey])
           formDataTotp = form[this.totpFieldKey] && String(form[this.totpFieldKey])
-          console.log('authenticate: isPost:', { formDataEmail, formDataTotp })
 
           /**
            * Re-send TOTP - User has requested a new TOTP.
@@ -445,7 +438,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
             sessionTotp &&
             sessionTotpExpiresAt
           ) {
-            console.log('authenticate: re-send totp: deactivate sessionTotp')
             const expiresAt = new Date(sessionTotpExpiresAt)
             await this.updateTOTP(sessionTotp, { active: false }, expiresAt)
             formDataEmail = sessionEmail
@@ -461,7 +453,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
             sessionTotp &&
             sessionTotpExpiresAt
           ) {
-            console.log('authenticate: new email: deactivate sessionTotp')
             const expiresAt = new Date(sessionTotpExpiresAt)
             await this.updateTOTP(sessionTotp, { active: false }, expiresAt)
           }
@@ -633,7 +624,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
   private async _validateTOTP(sessionTotp: string, otp: string, expiresAt: Date) {
     // Retrieve encrypted TOTP from database.
     const dbTOTP = await this.readTOTP(sessionTotp)
-    console.log('_validateTOTP:', { sessionTotp, otp, expiresAt, dbTOTP })
     if (!dbTOTP || !dbTOTP.hash) throw new Error(this.customErrors.totpNotFound)
 
     if (dbTOTP.active !== true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,7 +493,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
             )
 
             // Send TOTP.
-            await this._sendTOTP({
+            await this.sendTOTP({
               email: formDataEmail,
               code: _otp,
               magicLink,
@@ -614,10 +614,6 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
   private async _validateEmailDefaults(email: string) {
     const regexEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/gm
     if (!regexEmail.test(email)) throw new Error(this.customErrors.invalidEmail)
-  }
-
-  private async _sendTOTP(data: SendTOTPOptions) {
-    await this.sendTOTP({ ...data })
   }
 
   private async _validateTOTP(sessionTotp: string, otp: string, expiresAt: Date) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import {
   verifyJWT,
 } from './utils.js'
 import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from './constants.js'
-import { CreateContextOptions } from 'vm'
 
 /**
  * The TOTP data which the application stores and uses in CRUD functions provided by the application.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,6 @@
 import type { TOTPGenerationOptions, MagicLinkGenerationOptions } from './index.js'
-
 import { SignJWT, jwtVerify } from 'jose'
 import { generateTOTP as _generateTOTP } from '@epic-web/totp'
-
 import { ERRORS } from './constants.js'
 
 // @ts-expect-error - `thirty-two` is not typed.
@@ -31,10 +29,7 @@ export function generateMagicLink(
     return undefined
   }
 
-  const url = new URL(
-    options.callbackPath ?? '/',
-    new URL(options.request.url).origin,
-  )
+  const url = new URL(options.callbackPath ?? '/', new URL(options.request.url).origin)
   url.searchParams.set(options.param, options.code)
 
   return url.toString()

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,10 @@
+import type { Session } from '@remix-run/server-runtime'
+import type { SendTOTPOptions, TOTPData } from '../src/index'
+
 import { describe, test, expect, afterEach, vi } from 'vitest'
 import { AuthorizationError } from 'remix-auth'
 
-import { type SendTOTPOptions, type TOTPData, TOTPStrategy } from '../src/index'
+import { TOTPStrategy } from '../src/index'
 import { generateTOTP, generateMagicLink, signJWT } from '../src/utils'
 import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from '../src/constants'
 
@@ -14,7 +17,6 @@ import {
   DEFAULT_EMAIL,
   sessionStorage,
 } from './utils'
-import { type Session } from '@remix-run/server-runtime'
 
 /**
  * Mocks.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -39,7 +39,6 @@ describe('[ Basics ]', () => {
         createTOTP,
         readTOTP,
         updateTOTP,
-        storeTOTP,
         sendTOTP,
         handleTOTP,
       },
@@ -74,7 +73,6 @@ describe('[ Basics ]', () => {
         createTOTP,
         readTOTP,
         updateTOTP,
-        storeTOTP,
         sendTOTP,
         handleTOTP,
       },
@@ -105,7 +103,6 @@ describe('[ Basics ]', () => {
         createTOTP,
         readTOTP,
         updateTOTP,
-        storeTOTP,
         sendTOTP,
         handleTOTP,
         customErrors: {
@@ -144,7 +141,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -177,7 +173,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -210,7 +205,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -224,7 +218,7 @@ describe('[ TOTP ]', () => {
         })
         .catch((error) => error)
 
-      expect(storeTOTP).toHaveBeenCalledTimes(1)
+      expect(createTOTP).toHaveBeenCalledTimes(1)
     })
 
     test('Should call sendTOTP function.', async () => {
@@ -243,7 +237,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -276,7 +269,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -314,7 +306,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -356,7 +347,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
           validateEmail,
@@ -370,10 +360,7 @@ describe('[ TOTP ]', () => {
         })
         .catch((error) => error)
 
-      // Called 2 times:
-      // - 1st: Inside 'Re-send TOTP'.
-      // - 2nd: Inside 'First TOTP request' after storing the TOTP.
-      expect(handleTOTP).toHaveBeenCalledTimes(2)
+      expect(handleTOTP).toHaveBeenCalledTimes(1)
       expect(validateEmail).toHaveBeenCalledTimes(1)
     })
   })
@@ -395,7 +382,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -428,7 +414,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -463,7 +448,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
           customErrors: {
@@ -509,7 +493,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -556,7 +539,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -605,7 +587,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -664,7 +645,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -727,7 +707,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -765,7 +744,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -814,7 +792,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },
@@ -865,7 +842,6 @@ describe('[ TOTP ]', () => {
           createTOTP,
           readTOTP,
           updateTOTP,
-          storeTOTP,
           sendTOTP,
           handleTOTP,
         },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach, vi } from 'vitest'
 import { AuthorizationError } from 'remix-auth'
 
-import { SendTOTPOptions, TOTPData, TOTPStrategy } from '../src/index'
+import { type SendTOTPOptions, type TOTPData, TOTPStrategy } from '../src/index'
 import { generateTOTP, generateMagicLink, signJWT } from '../src/utils'
 import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from '../src/constants'
 
@@ -14,7 +14,7 @@ import {
   DEFAULT_EMAIL,
   sessionStorage,
 } from './utils'
-import { Session } from '@remix-run/server-runtime'
+import { type Session } from '@remix-run/server-runtime'
 
 /**
  * Mocks.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -19,6 +19,9 @@ import {
  * Mocks.
  */
 export const verify = vi.fn()
+export const createTOTP = vi.fn()
+export const readTOTP = vi.fn()
+export const updateTOTP = vi.fn()
 export const storeTOTP = vi.fn()
 export const sendTOTP = vi.fn()
 export const handleTOTP = vi.fn()
@@ -31,7 +34,15 @@ afterEach(() => {
 describe('[ Basics ]', () => {
   test('Should contain the name of the Strategy.', async () => {
     const strategy = new TOTPStrategy(
-      { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+      {
+        secret: SECRET_ENV,
+        createTOTP,
+        readTOTP,
+        updateTOTP,
+        storeTOTP,
+        sendTOTP,
+        handleTOTP,
+      },
       verify,
     )
 
@@ -58,7 +69,15 @@ describe('[ Basics ]', () => {
     })
 
     const strategy = new TOTPStrategy(
-      { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+      {
+        secret: SECRET_ENV,
+        createTOTP,
+        readTOTP,
+        updateTOTP,
+        storeTOTP,
+        sendTOTP,
+        handleTOTP,
+      },
       verify,
     )
     const result = await strategy
@@ -83,6 +102,9 @@ describe('[ Basics ]', () => {
     const strategy = new TOTPStrategy(
       {
         secret: SECRET_ENV,
+        createTOTP,
+        readTOTP,
+        updateTOTP,
         storeTOTP,
         sendTOTP,
         handleTOTP,
@@ -117,7 +139,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = await strategy
@@ -142,7 +172,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = await strategy
@@ -167,7 +205,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       await strategy
@@ -192,7 +238,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       await strategy
@@ -217,7 +271,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -247,7 +309,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -281,7 +351,16 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP, validateEmail },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+          validateEmail,
+        },
         verify,
       )
       await strategy
@@ -311,7 +390,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       await strategy
@@ -336,7 +423,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -365,6 +460,9 @@ describe('[ TOTP ]', () => {
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
           storeTOTP,
           sendTOTP,
           handleTOTP,
@@ -406,7 +504,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -445,7 +551,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -486,7 +600,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -537,7 +659,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -592,7 +722,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -622,7 +760,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -663,7 +809,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy
@@ -706,7 +860,15 @@ describe('[ TOTP ]', () => {
       })
 
       const strategy = new TOTPStrategy(
-        { secret: SECRET_ENV, storeTOTP, sendTOTP, handleTOTP },
+        {
+          secret: SECRET_ENV,
+          createTOTP,
+          readTOTP,
+          updateTOTP,
+          storeTOTP,
+          sendTOTP,
+          handleTOTP,
+        },
         verify,
       )
       const result = (await strategy


### PR DESCRIPTION
Closes #35 [ Refactor ] Decomplect handleTOTP() API

This refactor addresses the application API for totp data storage by

- Making the CRUD operations explicit
  - Separating handleTOTP() into readTOTP() and updateTOTP().
  - Renaming storeTOTP() to createTOTP().
- Adding expiresAt to createTOTP() and updateTOTP()

Totp data is ephemeral since it expires after some time. Session data is also ephemeral and this PR mimics Remix's API for session storage (https://remix.run/docs/en/main/utils/sessions#createsessionstorage). 

Conveying expiresAt during create and update simplifies implementation using key-value stores where expiresAt may be metadata.

@dev-xo: Please let me know if you want to move forward with this PR and I'll incorporate any feedback, update README, and add migration notes since breaking change. It would also be helpful to have a dev version in npm for further testing with totp-starter-example and remix-auth-totp-cloudflare-example. And I'm open to learning how to deploy dev versions.