### PR TITLE
Firm up tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   generateMagicLink,
   signJWT,
   verifyJWT,
+  ensureStringOrUndefined,
 } from './utils.js'
 import { STRATEGY_NAME, FORM_FIELDS, SESSION_KEYS, ERRORS } from './constants.js'
 
@@ -536,13 +537,18 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
 
         if ((isPOST && formDataTotp) || (isGET && magicLinkTotp)) {
           // Validation.
-          if (!sessionEmail || !sessionTotp || !sessionTotpExpiresAt)
+          if (!sessionEmail || !sessionTotp || !sessionTotpExpiresAt) {
             throw new Error(this.customErrors.inactiveTotp)
+          }
+
           const expiresAt = new Date(sessionTotpExpiresAt)
-          if (isPOST && formDataTotp)
+
+          if (isPOST && formDataTotp) {
             await this._validateTOTP(sessionTotp, formDataTotp, expiresAt)
-          if (isGET && magicLinkTotp)
+          }
+          if (isGET && magicLinkTotp) {
             await this._validateTOTP(sessionTotp, magicLinkTotp, expiresAt)
+          }
 
           // Invalidation.
           await this.updateTOTP(sessionTotp, { active: false }, expiresAt)
@@ -651,11 +657,4 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
       throw new Error(this.customErrors.invalidTotp)
     }
   }
-}
-
-function ensureStringOrUndefined(value: unknown) {
-  if (typeof value !== 'string' && value !== undefined) {
-    throw new Error('Value must be a string or undefined')
-  }
-  return value
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,3 +76,13 @@ export async function verifyJWT({ jwt, secretKey }: VerifyJWTOptions) {
     throw new Error(ERRORS.INVALID_JWT)
   }
 }
+
+/**
+ * Miscellaneous.
+ */
+export function ensureStringOrUndefined(value: unknown) {
+  if (typeof value !== 'string' && value !== undefined) {
+    throw new Error('Value must be a string or undefined.')
+  }
+  return value
+}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import type { Session } from '@remix-run/server-runtime'
 import type { SendTOTPOptions, TOTPData } from '../src/index'
 
-import { describe, test, expect, afterEach, vi, beforeEach } from 'vitest'
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
 import { AuthorizationError } from 'remix-auth'
 
 import { TOTPStrategy } from '../src/index'
@@ -201,6 +201,7 @@ describe('[ TOTP ]', () => {
         },
         verify,
       )
+
       await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
@@ -318,7 +319,7 @@ describe('[ TOTP ]', () => {
         headers: {
           cookie: await sessionStorage.commitSession(session),
         },
-        body: new FormData(), // Empty form data indicates re-send new TOTP
+        body: new FormData(), // Empty form data indicates re-send new TOTP.
       })
 
       const strategy = new TOTPStrategy(
@@ -348,6 +349,7 @@ describe('[ TOTP ]', () => {
     test('Should invalidate current TOTP.', async () => {
       let totpData: TOTPData | undefined
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -372,10 +374,12 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           body: formData,
         })
+
         await strategy
           .authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -390,6 +394,7 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(totpData).toBeDefined()
       expect(totpData?.active).toBeTruthy()
       expect(session).toBeDefined()
@@ -398,6 +403,7 @@ describe('[ TOTP ]', () => {
         const { otp } = generateTOTP(TOTP_GENERATION_DEFAULTS)
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, otp)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           headers: {
@@ -405,6 +411,7 @@ describe('[ TOTP ]', () => {
           },
           body: formData,
         })
+
         await expect(() =>
           strategy.authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -412,12 +419,15 @@ describe('[ TOTP ]', () => {
           }),
         ).rejects.toThrowError(ERRORS.INVALID_TOTP)
       }
+
       expect(totpData).toBeDefined()
       expect(totpData?.active).toBeTruthy()
+
       {
         const { otp } = generateTOTP(TOTP_GENERATION_DEFAULTS)
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, otp)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           headers: {
@@ -425,6 +435,7 @@ describe('[ TOTP ]', () => {
           },
           body: formData,
         })
+
         await expect(() =>
           strategy.authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -432,6 +443,7 @@ describe('[ TOTP ]', () => {
           }),
         ).rejects.toThrowError(ERRORS.INACTIVE_TOTP)
       }
+
       expect(totpData).toBeDefined()
       expect(totpData?.active).toBeFalsy()
     })
@@ -451,10 +463,12 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           body: formData,
         })
+
         await strategy
           .authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -481,6 +495,7 @@ describe('[ TOTP ]', () => {
           },
           body: formData,
         })
+
         await expect(() =>
           strategy.authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -493,6 +508,7 @@ describe('[ TOTP ]', () => {
     test('Should throw a custom Error message on missing TOTP from database.', async () => {
       const CUSTOM_ERROR = 'Custom error message.'
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -509,10 +525,12 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           body: formData,
         })
+
         await strategy
           .authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -539,6 +557,7 @@ describe('[ TOTP ]', () => {
           },
           body: formData,
         })
+
         await expect(() =>
           strategy.authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -682,6 +701,7 @@ describe('[ TOTP ]', () => {
       let totpData: TOTPData | undefined
       let sendTOTPOptions: SendTOTPOptions | undefined
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -704,6 +724,7 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}/login`, {
           method: 'POST',
           body: formData,
@@ -723,6 +744,7 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(totpData).toBeDefined()
       expect(totpData?.active).toBeTruthy()
       expect(sendTOTPOptions).toBeDefined()
@@ -733,6 +755,7 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, sendTOTPOptions!.code)
+
         const request = new Request(`${HOST_URL}/verify`, {
           method: 'POST',
           headers: {
@@ -753,6 +776,7 @@ describe('[ TOTP ]', () => {
       let totpData: TOTPData | undefined
       let sendTOTPOptions: SendTOTPOptions | undefined
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -775,6 +799,7 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}/login`, {
           method: 'POST',
           body: formData,
@@ -793,6 +818,7 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(totpData).toBeDefined()
       expect(totpData?.active).toBeTruthy()
       expect(sendTOTPOptions).toBeDefined()
@@ -856,6 +882,7 @@ describe('[ TOTP ]', () => {
       let totpData: TOTPData | undefined
       let sendTOTPOptions: SendTOTPOptions | undefined
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -878,6 +905,7 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}/login`, {
           method: 'POST',
           body: formData,
@@ -896,12 +924,15 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(totpData).toBeDefined()
       expect(sendTOTPOptions).toBeDefined()
       expect(session).toBeDefined()
+
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, sendTOTPOptions!.code)
+
         const request = new Request(`${HOST_URL}/verify`, {
           method: 'POST',
           headers: {
@@ -925,9 +956,11 @@ describe('[ TOTP ]', () => {
 
     test('Should contain user property in session.', async () => {
       const user = { name: 'Joe Schmoe' }
+
       let totpData: TOTPData | undefined
       let sendTOTPOptions: SendTOTPOptions | undefined
       let session: Session | undefined
+
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
@@ -971,9 +1004,11 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(totpData).toBeDefined()
       expect(sendTOTPOptions).toBeDefined()
       expect(session).toBeDefined()
+
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, sendTOTPOptions!.code)
@@ -998,6 +1033,7 @@ describe('[ TOTP ]', () => {
             } else throw reason
           })
       }
+
       expect(session).toBeDefined()
       expect(session!.data).toHaveProperty('user')
       expect(session!.get('user')).toEqual(user)
@@ -1045,10 +1081,12 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           body: formData,
         })
+
         await strategy
           .authenticate(request, sessionStorage, {
             ...AUTH_OPTIONS,
@@ -1078,6 +1116,7 @@ describe('[ TOTP ]', () => {
       {
         const formData = new FormData()
         formData.append(FORM_FIELDS.TOTP, sendTOTPOptions!.code)
+
         const request = new Request(`${HOST_URL}`, {
           method: 'POST',
           headers: {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,7 @@
 import type { Session } from '@remix-run/server-runtime'
 import type { SendTOTPOptions, TOTPData } from '../src/index'
 
-import { describe, test, expect, afterEach, vi } from 'vitest'
+import { describe, test, expect, afterEach, vi, beforeEach } from 'vitest'
 import { AuthorizationError } from 'remix-auth'
 
 import { TOTPStrategy } from '../src/index'
@@ -28,7 +28,12 @@ export const updateTOTP = vi.fn()
 export const sendTOTP = vi.fn()
 export const validateEmail = vi.fn()
 
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -485,7 +490,7 @@ describe('[ TOTP ]', () => {
       }
     })
 
-    test.only('Should throw a custom Error message on missing TOTP from database.', async () => {
+    test('Should throw a custom Error message on missing TOTP from database.', async () => {
       const CUSTOM_ERROR = 'Custom error message.'
       const strategy = new TOTPStrategy(
         {
@@ -673,60 +678,73 @@ describe('[ TOTP ]', () => {
       expect(result).toEqual(new AuthorizationError(ERRORS.INACTIVE_TOTP))
     })
 
-    test('Should throw an Error on invalid (expired) TOTP verification.', async () => {
-      readTOTP.mockImplementation(() =>
-        Promise.resolve({ hash: signedTotp, attempts: 0, active: true }),
-      )
-
-      const { otp: _otp, ...totp } = generateTOTP({
-        ...TOTP_GENERATION_DEFAULTS,
-        period: 0.1,
-      })
-      const signedTotp = await signJWT({
-        payload: totp,
-        expiresIn: TOTP_GENERATION_DEFAULTS.period,
-        secretKey: SECRET_ENV,
-      })
-
-      const formData = new FormData()
-      formData.append(FORM_FIELDS.TOTP, _otp)
-
-      const session = await sessionStorage.getSession()
-      session.set(SESSION_KEYS.TOTP, signedTotp)
-
-      const request = new Request(`${HOST_URL}`, {
-        method: 'POST',
-        headers: {
-          cookie: await sessionStorage.commitSession(session),
-        },
-        body: formData,
-      })
-
-      // Wait for TOTP expiration.
-      await new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(true)
-        }, 200)
-      })
-
+    test.only('Should throw an Error on invalid (expired) TOTP verification.', async () => {
+      let totpData: TOTPData | undefined
+      let sendTOTPOptions: SendTOTPOptions | undefined
+      let session: Session | undefined
       const strategy = new TOTPStrategy(
         {
           secret: SECRET_ENV,
-          createTOTP,
-          readTOTP,
+          createTOTP: async (data) => {
+            expect(totpData).not.toBeDefined()
+            totpData = data
+          },
+          readTOTP: async (hash) => {
+            expect(totpData).toBeDefined()
+            expect(totpData?.hash).toBe(hash)
+            return totpData!
+          },
           updateTOTP,
-          sendTOTP,
+          sendTOTP: async (options) => {
+            sendTOTPOptions = options
+          },
         },
         verify,
       )
-      const result = (await strategy
-        .authenticate(request, sessionStorage, {
-          ...AUTH_OPTIONS,
-          successRedirect: '/',
+      {
+        const formData = new FormData()
+        formData.append(FORM_FIELDS.EMAIL, DEFAULT_EMAIL)
+        const request = new Request(`${HOST_URL}/login`, {
+          method: 'POST',
+          body: formData,
         })
-        .catch((error) => error)) as Response
 
-      expect(result).toEqual(new AuthorizationError(ERRORS.INVALID_TOTP))
+        await strategy
+          .authenticate(request, sessionStorage, {
+            ...AUTH_OPTIONS,
+            successRedirect: '/verify',
+          })
+          .catch(async (reason) => {
+            if (reason instanceof Response) {
+              expect(reason.status).toBe(302)
+              session = await sessionStorage.getSession(
+                reason.headers.get('set-cookie') ?? '',
+              )
+            } else throw reason
+          })
+      }
+      expect(totpData).toBeDefined()
+      expect(totpData?.active).toBeTruthy()
+      expect(sendTOTPOptions).toBeDefined()
+      expect(session).toBeDefined()
+      vi.setSystemTime(new Date(Date.now() + 1000 * 60 * (TOTP_GENERATION_DEFAULTS.period + 1)))
+      {
+        const formData = new FormData()
+        formData.append(FORM_FIELDS.TOTP, sendTOTPOptions!.code)
+        const request = new Request(`${HOST_URL}/verify`, {
+          method: 'POST',
+          headers: {
+            cookie: await sessionStorage.commitSession(session!),
+          },
+          body: formData,
+        })
+        await expect(() =>
+          strategy.authenticate(request, sessionStorage, {
+            ...AUTH_OPTIONS,
+            successRedirect: '/',
+          }),
+        ).rejects.toThrow(ERRORS.INACTIVE_TOTP)
+      }
     })
 
     test('Should throw an Error on invalid (expired) magic-link TOTP verification.', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -58,11 +58,10 @@ describe('[ Basics ]', () => {
       { createTOTP, readTOTP, updateTOTP, sendTOTP },
       verify,
     )
-    const result = await strategy
-      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS })
-      .catch((error) => error)
 
-    expect(result).toEqual(new AuthorizationError(ERRORS.REQUIRED_ENV_SECRET))
+    await expect(() =>
+      strategy.authenticate(request, sessionStorage, { ...AUTH_OPTIONS }),
+    ).rejects.toThrow(ERRORS.REQUIRED_ENV_SECRET)
   })
 
   test('Should throw an Error on missing required successRedirect option.', async () => {
@@ -80,11 +79,10 @@ describe('[ Basics ]', () => {
       },
       verify,
     )
-    const result = await strategy
-      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS })
-      .catch((error) => error)
 
-    expect(result).toEqual(new AuthorizationError(ERRORS.REQUIRED_SUCCESS_REDIRECT_URL))
+    await expect(() =>
+      strategy.authenticate(request, sessionStorage, { ...AUTH_OPTIONS }),
+    ).rejects.toThrow(ERRORS.REQUIRED_SUCCESS_REDIRECT_URL)
   })
 
   test('Should throw a custom Error message.', async () => {
@@ -111,14 +109,13 @@ describe('[ Basics ]', () => {
       },
       verify,
     )
-    const result = await strategy
-      .authenticate(request, sessionStorage, {
+
+    await expect(() =>
+      strategy.authenticate(request, sessionStorage, {
         ...AUTH_OPTIONS,
         successRedirect: '/',
-      })
-      .catch((error) => error)
-
-    expect(result).toEqual(new AuthorizationError(CUSTOM_ERROR))
+      }),
+    ).rejects.toThrow(CUSTOM_ERROR)
   })
 })
 
@@ -143,14 +140,13 @@ describe('[ TOTP ]', () => {
         },
         verify,
       )
-      const result = await strategy
-        .authenticate(request, sessionStorage, {
+
+      await expect(() =>
+        strategy.authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
           successRedirect: '/',
-        })
-        .catch((error) => error)
-
-      expect(result).toEqual(new AuthorizationError(ERRORS.REQUIRED_EMAIL))
+        }),
+      ).rejects.toThrow(ERRORS.REQUIRED_EMAIL)
     })
 
     test('Should throw an Error on invalid form email.', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -59,7 +59,7 @@ describe('[ Basics ]', () => {
       verify,
     )
     const result = await strategy
-      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS, throwOnError: true })
+      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS })
       .catch((error) => error)
 
     expect(result).toEqual(new AuthorizationError(ERRORS.REQUIRED_ENV_SECRET))
@@ -81,7 +81,7 @@ describe('[ Basics ]', () => {
       verify,
     )
     const result = await strategy
-      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS, throwOnError: true })
+      .authenticate(request, sessionStorage, { ...AUTH_OPTIONS })
       .catch((error) => error)
 
     expect(result).toEqual(new AuthorizationError(ERRORS.REQUIRED_SUCCESS_REDIRECT_URL))
@@ -95,7 +95,6 @@ describe('[ Basics ]', () => {
 
     const request = new Request(`${HOST_URL}`, {
       method: 'POST',
-      headers: { host: HOST_URL },
       body: formData,
     })
 
@@ -115,7 +114,6 @@ describe('[ Basics ]', () => {
     const result = await strategy
       .authenticate(request, sessionStorage, {
         ...AUTH_OPTIONS,
-        throwOnError: true,
         successRedirect: '/',
       })
       .catch((error) => error)
@@ -132,7 +130,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -149,7 +146,6 @@ describe('[ TOTP ]', () => {
       const result = await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)
@@ -163,7 +159,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -180,7 +175,6 @@ describe('[ TOTP ]', () => {
       const result = await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)
@@ -194,7 +188,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -211,7 +204,6 @@ describe('[ TOTP ]', () => {
       await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)
@@ -225,7 +217,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -242,7 +233,6 @@ describe('[ TOTP ]', () => {
       await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)
@@ -256,7 +246,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -273,7 +262,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -293,7 +281,6 @@ describe('[ TOTP ]', () => {
 
       const request = new Request(`${HOST_URL}`, {
         method: 'POST',
-        headers: { host: HOST_URL },
         body: formData,
       })
 
@@ -383,7 +370,6 @@ describe('[ TOTP ]', () => {
       await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)
@@ -414,7 +400,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -450,7 +435,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -491,7 +475,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -536,7 +519,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -583,7 +565,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -640,7 +621,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -701,7 +681,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -737,7 +716,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -784,7 +762,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response
@@ -833,7 +810,6 @@ describe('[ TOTP ]', () => {
       const result = (await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
-          throwOnError: true,
           successRedirect: '/',
         })
         .catch((error) => error)) as Response

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,7 +10,7 @@ import * as crypto from 'crypto'
  * Constants.
  */
 export const SECRET_ENV = 'SECRET_ENV'
-export const HOST_URL = 'http://localhost:3000'
+export const HOST_URL = 'https://prodserver.com'
 export const DEFAULT_EMAIL = 'localhost@3000.com'
 
 /**
@@ -21,6 +21,7 @@ export const AUTH_OPTIONS = {
   sessionKey: 'user',
   sessionErrorKey: 'error',
   sessionStrategyKey: 'strategy',
+  throwOnError: true,
 } satisfies AuthenticateOptions
 
 export const TOTP_GENERATION_DEFAULTS = {


### PR DESCRIPTION
This PR firms up the tests. 

It checks more values within API mocks. Discovered cases where `readTOTP` was called with an undefined hash. Investigation of `authenticate()` revealed that session vars where getting typed as `any` with `session.get()`. `ensureStringOrUndefined()` narrows the type to string/undefined or throws error. Then typescript squiggled on places where the code assumed the session var was defined leading to narrowing type checks.