### PR TITLE
[ Feat ]: Add support for TOTP resent message.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@ export const SESSION_KEYS = {
   EMAIL: 'auth:email',
   TOTP: 'auth:totp',
   TOTP_EXPIRES_AT: 'auth:totp:expiresAt',
+  FIRST_OTP_REQUESTED: 'auth:totp:firstOtpRequested',
+  OTP_RESENT: "auth:totp:resent"
 } as const
 
 export const ERRORS = {


### PR DESCRIPTION
## Implementation 

1. I am thinking of keeping one flag in session to check if OTP has been already requested once. which is reset whenever email is different from email in session.
2. If OTP is already requested, we just flash a message whenever there is new OTP request. 

Please let me know if any changes are required or if it should be done in some different way. 


