### PR TITLE
Pass along any AppLoadContext passed during authentication

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { Session, SessionStorage } from '@remix-run/server-runtime'
+import type { AppLoadContext, Session, SessionStorage } from '@remix-run/server-runtime'
 import type { AuthenticateOptions, StrategyVerifyCallback } from 'remix-auth'
 
 import { redirect } from '@remix-run/server-runtime'
@@ -106,6 +106,11 @@ export interface SendTOTPOptions {
    * The form data of the request.
    */
   formData: FormData
+
+  /**
+   * The app context
+   */
+  context?: AppLoadContext
 }
 
 /**
@@ -236,6 +241,11 @@ export interface TOTPVerifyParams {
    * The Request object.
    */
   request: Request
+
+  /**
+   * The Request object.
+   */
+  context?: AppLoadContext
 }
 
 export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
@@ -341,6 +351,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
           code,
           magicLink,
           formData,
+          context: options.context,
           request,
         })
 
@@ -367,6 +378,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
         const user = await this.verify({
           email: sessionEmail,
           formData: request.method === 'POST' ? formData : undefined,
+          context: options.context,
           request,
         })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_EMAIL,
   sessionStorage,
   MAGIC_LINK_PATH,
+  DEFAULT_CONTEXT,
 } from './utils'
 
 /**
@@ -86,11 +87,13 @@ describe('[ Basics ]', () => {
 describe('[ TOTP ]', () => {
   describe('Generate/Send TOTP', () => {
     test('Should generate/send TOTP for form email.', async () => {
+      const context = {}
       sendTOTP.mockImplementation(async (options: SendTOTPOptions) => {
         expect(options.email).toBe(DEFAULT_EMAIL)
         expect(options.code).to.not.equal('')
         expect(options.request).toBeInstanceOf(Request)
         expect(options.formData).toBeInstanceOf(FormData)
+        expect(options.context).toBe(context)
       })
       const strategy = new TOTPStrategy(TOTP_STRATEGY_OPTIONS, verify)
       const formData = new FormData()
@@ -102,6 +105,7 @@ describe('[ TOTP ]', () => {
       await strategy
         .authenticate(request, sessionStorage, {
           ...AUTH_OPTIONS,
+          context: context,
           successRedirect: '/verify',
           failureRedirect: '/login',
         })
@@ -539,9 +543,10 @@ describe('[ TOTP ]', () => {
 
       const strategy = new TOTPStrategy<typeof user>(
         { ...TOTP_STRATEGY_OPTIONS, ...totpStrategyOptions },
-        async ({ email, formData, request }) => {
+        async ({ email, formData, request, context }) => {
           expect(email).toBe(DEFAULT_EMAIL)
           expect(request).toBeInstanceOf(Request)
+          expect(context).toBe(DEFAULT_CONTEXT)
           if (request.method === 'POST') {
             expect(formData).toBeInstanceOf(FormData)
           } else {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -12,6 +12,7 @@ import * as crypto from 'crypto'
 export const SECRET_ENV = 'SECRET_ENV'
 export const HOST_URL = 'https://prodserver.com'
 export const DEFAULT_EMAIL = 'user@gmail.com'
+export const DEFAULT_CONTEXT = {}
 export const MAGIC_LINK_PATH = '/magic-link'
 
 /**
@@ -22,6 +23,7 @@ export const AUTH_OPTIONS = {
   sessionKey: 'user',
   sessionErrorKey: 'error',
   sessionStrategyKey: 'strategy',
+  context: DEFAULT_CONTEXT,
 } satisfies AuthenticateOptions
 
 export const TOTP_GENERATION_DEFAULTS: Required<TOTPGenerationOptions> = {


### PR DESCRIPTION
In the [remix-auth/strategy](https://github.com/sergiodxa/remix-auth/blob/main/src/strategy.ts#L51) there is a context param that is intended to be passed to the strategy. This PR merely passes along the `context` along from `authenticator.authenticate(..., ..., {context: appLoadContext})` to the `sendTOTP` and `verify` functions.