### PR TITLE
docs: Fix maxAge unit from milliseconds to seconds.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -117,7 +117,7 @@ authenticator.use(
 ```
 
 > [!TIP]
-> You can specify session duration with `maxAge` in milliseconds. Default is `undefined`, persisting across browser restarts.
+> You can specify session duration with `maxAge` in seconds. Default is `undefined`, persisting across browser restarts.
 
 ### 2: Implementing the Strategy Logic.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -114,7 +114,7 @@ export interface TOTPStrategyOptions<User> {
    */
   secret: string
   /**
-   * The maximum age of the session in milliseconds.
+   * The maximum age of the session in seconds.
    * @default undefined
    */
   maxAge?: number


### PR DESCRIPTION
Just a small docs fix. The maxAge value is to be expressed in seconds, not milliseconds.