### PR TITLE
[ Feat ] Add error for magic link in another Browser Instance

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -111,6 +111,10 @@ export interface CustomErrorsOptions {
    * The expired TOTP error message.
    */
   expiredTotp?: string
+  /**
+   * The missing session email error message.
+   */
+  missingSessionEmail?: string
 }
 
 authenticator.use(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const ERRORS = {
   INVALID_EMAIL: 'Email is not valid.',
   INVALID_TOTP: 'Code is not valid.',
   EXPIRED_TOTP: 'Code has expired.',
+  MISSING_SESSION_EMAIL: 'Missing email to verify. Check that same browser used for verification.',
 
   // Miscellaneous errors.
   REQUIRED_ENV_SECRET: 'Missing required .env secret.',

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,11 @@ export interface CustomErrorsOptions {
    * The expired TOTP error message.
    */
   expiredTotp?: string
+
+  /**
+   * The missing session email error message.
+   */
+  missingSessionEmail?: string
 }
 
 /**
@@ -294,6 +299,7 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
     invalidEmail: ERRORS.INVALID_EMAIL,
     invalidTotp: ERRORS.INVALID_TOTP,
     expiredTotp: ERRORS.EXPIRED_TOTP,
+    missingSessionEmail: ERRORS.MISSING_SESSION_EMAIL,
   }
 
   constructor(
@@ -388,7 +394,8 @@ export class TOTPStrategy<User> extends Strategy<User, TOTPVerifyParams> {
 
       const code = formDataCode ?? this._getMagicLinkCode(request)
       if (code) {
-        if (!sessionEmail || !sessionTotp) throw new Error(this.customErrors.expiredTotp)
+        if (!sessionEmail) throw new Error(this.customErrors.missingSessionEmail);
+        if (!sessionTotp) throw new Error(this.customErrors.expiredTotp)
         await this._validateTOTP({ code, sessionTotp, session, sessionStorage, options })
 
         const user = await this.verify({


### PR DESCRIPTION
I was setting this up in my project and was confused during my testing when I kept seeing an expired code error - it was because I was using different browser instances that didn't share the email in the session cookie. I believe this sort of thing is common in email clients (not sharing browser sessions) so I thought it would be helpful to expose this error in the library so users can customize messaging to clients about why the magic link is actually broken even if it was just generated (not due to the code expiring!).

Alternatively could throw REQUIRED_EMAIL error here, but then it would require the user to have context on the session data  to discriminate between other REQUIRED_EMAIL errors and I am not sure what type of encapsulation you want.